### PR TITLE
Changed podspec to include all files from Headers folder in source_files

### DIFF
--- a/SITUBluetooth.podspec
+++ b/SITUBluetooth.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
     spec.platform = :ios, '8.1'
     spec.requires_arc = true
     
-    spec.source_files = 'SITUBluetooth.framework/Headers/SITUBluetooth.h'
+    spec.source_files = 'SITUBluetooth.framework/Headers/*'
 	spec.preserve_paths = 'SITUBluetooth.framework/*'
 	spec.vendored_frameworks = 'SITUBluetooth.framework'
     spec.frameworks   = 'Foundation', 'CoreBluetooth'


### PR DESCRIPTION
Using CocoaPods 0.37.2 (I know... we should update) I got a build error saying that the `<SITUBluetooth/SITUBluetoothScaleController.h>` import could not be found in `SITUBluetooth.h`. Looking at the podspec I noticed only `SITUBluetooth.h` was included in `spec.source_files` and as a result that's the only file CocoaPods copies to its `Headers` folder.

This PR changes the podspec to make sure all the headers are exported correctly, this could be an issue only with our version of CocoaPods but I think it makes sense
